### PR TITLE
Action Response Components and Turns Hook

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -102,6 +102,11 @@ io.on('connection', (socket) => {
     console.log('no-response')
     io.sockets.emit('no-response')
   })
+
+  socket.on('next-action-response',(data)=>{
+    console.log('next-action-response',data)
+    io.sockets.emit('next-action-response',data)
+  })
 });
 
 server.listen(port, () => {

--- a/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useState } from "react"
-import { useActivateResponseHandlers, useTurns } from "@/lib/hooks"
-import { actionTypes } from "@/data"
+import { useTurns } from "@/lib/hooks"
 import { useGameStateContext } from "@/context/gameState"
 import { usePlayerContext} from "@/context/players"
 
-type ActionPromptProps = {
-  action:Actions,
-  setShowPrompt?:React.Dispatch<React.SetStateAction<string>>
-}
+
 export const ActionPrompt = ()=>{
   const {actionPrompt,socket,setActionPrompt} = useGameStateContext() || {}
   const {turnPlayer} = useTurns()
@@ -17,8 +13,6 @@ export const ActionPrompt = ()=>{
   const [showToUser, setShowToUser] = useState<string>('')
 
   const currentActionPrompt = actionPrompt?.[responseCount]
-
-  console.log('SHOW TO',showToUser,currentPlayerUsername)
 
   useEffect(()=>{
     setShowToUser(turnPlayer?.username ?? '')
@@ -31,7 +25,6 @@ export const ActionPrompt = ()=>{
       setShowToUser(data.showToUser)
       setResponseCount(prev=>prev+1)
       if(data.complete){
-        console.log("COMPLETE!!")
         setShowToUser('')
         setCustomOptions({})
         setResponseCount(0)
@@ -47,23 +40,19 @@ export const ActionPrompt = ()=>{
       currentActionPrompt?.submitCallBack(formData)
     }}>
       {Object.entries(currentActionPrompt?.options ?? {}).map(([name,options])=>(
-        <>
         <select key={`select-${name}`} name={name}>
           {options?.map(option=>(
             <option key={`option-${option}`} value={option}>{option}</option>
           ))}
         </select>
-        </>
       ))}
 
       {Object.entries(customOptions ?? {}).map(([name,options])=>(
-        <>
         <select key={`select-${name}`} name={name}>
           {options?.map(option=>(
             <option key={`option-${option}`} value={option}>{option}</option>
           ))}
         </select>
-        </>
       ))}
 
       <button type="submit" className="btn btn-blue">Submit Action Response</button>

--- a/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react"
+import { useActivateResponseHandlers, useTurns } from "@/lib/hooks"
+import { actionTypes } from "@/data"
+import { useGameStateContext } from "@/context/gameState"
+import { usePlayerContext} from "@/context/players"
+
+type ActionPromptProps = {
+  action:Actions,
+  setShowPrompt?:React.Dispatch<React.SetStateAction<string>>
+}
+export const ActionPrompt = ()=>{
+  const {actionPrompt,socket,setActionPrompt} = useGameStateContext() || {}
+  const {turnPlayer} = useTurns()
+  const {currentPlayerUsername} = usePlayerContext() || {}
+  const [responseCount,setResponseCount] = useState<number>(0)
+  const [customOptions,setCustomOptions] = useState<ActionPromptData["options"]>({})
+  const [showToUser, setShowToUser] = useState<string>('')
+
+  const currentActionPrompt = actionPrompt?.[responseCount]
+
+  console.log('SHOW TO',showToUser,currentPlayerUsername)
+
+  useEffect(()=>{
+    setShowToUser(turnPlayer?.username ?? '')
+  },[!!actionPrompt])
+ 
+  useEffect(()=>{
+    if(!socket) return
+    socket?.on('next-action-response',(data)=>{
+      if(data.customOptions)setCustomOptions(data.customOptions)
+      setShowToUser(data.showToUser)
+      setResponseCount(prev=>prev+1)
+      if(data.complete){
+        console.log("COMPLETE!!")
+        setShowToUser('')
+        setCustomOptions({})
+        setResponseCount(0)
+        if(setActionPrompt)setActionPrompt(null)
+      }
+    })
+  },[socket])
+
+  return currentActionPrompt && showToUser===currentPlayerUsername && (
+    <form onSubmit={(e)=>{
+      e.preventDefault()
+      const formData = new FormData(e.currentTarget)
+      currentActionPrompt?.submitCallBack(formData)
+    }}>
+      {Object.entries(currentActionPrompt?.options ?? {}).map(([name,options])=>(
+        <>
+        <select key={`select-${name}`} name={name}>
+          {options?.map(option=>(
+            <option key={`option-${option}`} value={option}>{option}</option>
+          ))}
+        </select>
+        </>
+      ))}
+
+      {Object.entries(customOptions ?? {}).map(([name,options])=>(
+        <>
+        <select key={`select-${name}`} name={name}>
+          {options?.map(option=>(
+            <option key={`option-${option}`} value={option}>{option}</option>
+          ))}
+        </select>
+        </>
+      ))}
+
+      <button type="submit" className="btn btn-blue">Submit Action Response</button>
+    </form>
+  )
+
+}

--- a/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
@@ -3,7 +3,6 @@ import { usePlayerContext } from "@/context/players"
 export const Hand = ()=>{
   const {players,currentPlayerUsername} =  usePlayerContext() || {}
   const currentCards = players?.find(p=>p.username===currentPlayerUsername)?.cards
-  console.log(currentCards)
   return (
   <div className="flex flex-wrap">
     hand:

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -1,9 +1,13 @@
 "use client"
 import {useEffect, useState } from "react"
 import { usePlayerContext } from "@/context/players"
-import { usePlayerSocket } from "@/lib/hooks"
 import { useGameStateContext } from "@/context/gameState"
-import { useActivateResponseHandlers,useInitGame } from "@/lib/hooks"
+import {
+  useActivateResponseHandlers,
+  useInitGame,
+  useTurns,
+  usePlayerSocket 
+} from "@/lib/hooks"
 import { actionTypes } from "@/data"
 import { Hand } from "@/app/[roomNumber]/hand"
 
@@ -16,7 +20,7 @@ type RoomParams = {
 
 const Room = ({params}:RoomParams)=>{
   const playerContext = usePlayerContext()
-  const {socket,deck,} = useGameStateContext() || {}
+  const {socket,deck, turnCount} = useGameStateContext() || {}
 
   const [users,setUsers] = useState<User | null>(null)
   const [username,setUsername] = useState<string>("")
@@ -29,10 +33,11 @@ const Room = ({params}:RoomParams)=>{
     sendNoResponse,
     currentActions,
     noResponses
-  } = useActivateResponseHandlers()
+  } = useActivateResponseHandlers({initListeners:true})
   const {createGameAssets} = useInitGame()
 
   const {joinRoom, clearPlayers}= usePlayerSocket()
+  const {endTurn} = useTurns()
 
   useEffect(()=>{
     //preSocketRef.current makes sure we don't double add listeners
@@ -78,6 +83,9 @@ const Room = ({params}:RoomParams)=>{
           <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.nope)}>
             send nope {JSON.stringify(allowedResponse)}
           </button>
+          <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.diffuse)}>
+            send diffuse {JSON.stringify(allowedResponse)}
+          </button>
           <button className="btn btn-blue" onClick={()=>sendNoResponse()}>
             no response
           </button>
@@ -122,7 +130,12 @@ const Room = ({params}:RoomParams)=>{
             create game assets(need at least one joined user for this to work)
         </button>
       </div>
-
+      <div className="border border-black">
+        <h1>{turnCount}</h1>
+        <button className="btn btn-blue" onClick={()=>endTurn()}>
+          end turn
+        </button>
+      </div>
     </div>
   )
 }

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -77,7 +77,7 @@ const Room = ({params}:RoomParams)=>{
           {JSON.stringify(currentActions)} no response:{noResponses}
         </h1>
         <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.favor)}>
-          shuffle
+          favor
         </button>
         {showResponsePrompt && (
           <div>

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/hooks"
 import { actionTypes } from "@/data"
 import { Hand } from "@/app/[roomNumber]/hand"
+import { ActionPrompt } from "@/app/[roomNumber]/ActionPrompt"
 
 
 type RoomParams = {
@@ -75,7 +76,7 @@ const Room = ({params}:RoomParams)=>{
           TEST Hook(To get this to work, you need to have 2 joined users with different usernames)
           {JSON.stringify(currentActions)} no response:{noResponses}
         </h1>
-        <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.shuffle)}>
+        <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.favor)}>
           shuffle
         </button>
         {showResponsePrompt && (
@@ -91,6 +92,7 @@ const Room = ({params}:RoomParams)=>{
           </button>
           </div>
         )}
+        <ActionPrompt/>
       </div>
 
       <div className="border border-black">

--- a/exploding-kittens-frontend/src/context/gameState.tsx
+++ b/exploding-kittens-frontend/src/context/gameState.tsx
@@ -7,8 +7,10 @@ type GameStateContextValues ={
   discardPile: Card[],
   turnCount: number,
   currentActions:Actions[],
+  actionPrompt: ActionPromptData[] | null,
   socket:Socket<ServerToClientEvents, ClientToServerEvents> | null,
   setSocket: React.Dispatch<React.SetStateAction<Socket<ServerToClientEvents, ClientToServerEvents> | null>>,
+  setActionPrompt: React.Dispatch<React.SetStateAction<ActionPromptData[] | null>>
   setDeck: React.Dispatch<React.SetStateAction<Card[]>>
   setDiscardPile: React.Dispatch<React.SetStateAction<Card[]>>
   setTurnCount: React.Dispatch<React.SetStateAction<number>>
@@ -24,6 +26,7 @@ export const GameStateContextProvider = ({children}:{
   const [discardPile, setDiscardPile]= useState<Card[]>([])
   const [turnCount, setTurnCount]= useState<number>(0)
   const [currentActions, setCurrentActions]= useState<Actions[]>([])
+  const [actionPrompt, setActionPrompt]= useState<ActionPromptData[] | null>(null)
   const [socket, setSocket]= useState<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null)
 
   return (
@@ -34,6 +37,8 @@ export const GameStateContextProvider = ({children}:{
         turnCount,
         currentActions,
         socket,
+        actionPrompt,
+        setActionPrompt,
         setSocket,
         setDeck,
         setDiscardPile,

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -65,6 +65,8 @@ export const useCardActions = ()=>{
     console.log('diffuse')
   }
 
+  //this needs to be added on each submitCallBack to trigger the next event
+  //or complete the event chain
   const submitResponseEvent = (
     showToUser:string,
     customOptions:ActionPromptData["options"]={},

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -1,12 +1,69 @@
 import { useGameStateContext } from "@/context/gameState"
-import { actionTypes } from "@/data"
+import { usePlayerContext } from "@/context/players"
+import { actionTypes, cardTypes } from "@/data"
+import { useEffect, useRef } from "react"
 
-export const useActions = ()=>{
-  const { setCurrentActions } = useGameStateContext() || {}
+export const useGameActions = ()=>{
+  const { deck,socket} = useGameStateContext() || {}
+  const {players}= usePlayerContext() || {}
+
+  const playerCurrentHand = (playerUsername:string)=>{
+    return players?.find(p=>p.username === playerUsername)?.cards ?? []
+  }
+
+  const setPlayerHand = (cards:Card[],playerUsername:string)=>{
+    const newPlayers = [...(players??[])]
+    const currPlayerIndx = players?.findIndex(p=>p.username === playerUsername)
+    if((currPlayerIndx || currPlayerIndx===0) && currPlayerIndx!==-1){
+      newPlayers[currPlayerIndx].cards = cards
+    }
+    socket?.emit('all-players',newPlayers)
+  }
+  
+  const drawCard = (playerUsername:string) =>{
+    if(deck){
+      const newCard = deck[deck.length-1]
+      setPlayerHand(
+        [ ...playerCurrentHand(playerUsername),newCard]
+        ,playerUsername
+      )
+      const newDeck = deck.slice(0,deck.length-1)
+      socket?.emit('deck',newDeck)
+      return newCard
+    }
+  }
+
+  const actions  = {
+    drawCard,
+    setPlayerHand,
+    playerCurrentHand
+  }
+
+  return actions
+}
+
+export const useCardActions = ()=>{
+  const { setCurrentActions,currentActions} = useGameStateContext() || {}
+  const diffuseActionRef = useRef<boolean>(false)
+
+  useEffect(()=>{
+    if(diffuseActionRef.current){
+      //set state action complete ++
+    }
+    //shouldn't listen for global state data
+  },[currentActions?.length])
   
   const nopeAction = () =>{
     console.log('activate nope')
     if(setCurrentActions) setCurrentActions(prev=>prev.slice(0,prev.length-1))
+  }
+
+  const diffuseAction = () =>{
+    console.log('activate diffuse')
+    if(setCurrentActions) setCurrentActions(
+      prev=>prev.filter(prev=>prev!==cardTypes.exploding.type)
+    )
+    diffuseActionRef.current = true
   }
 
 type ActionImpl =  {
@@ -15,8 +72,10 @@ type ActionImpl =  {
   const actions:ActionImpl  = {
     //make this objects with an impl method
     [actionTypes.attack]:()=>null,
-    [actionTypes.diffuse]:()=>null,
-    [actionTypes.exploding]:()=>null,
+    [actionTypes.diffuse]:diffuseAction,
+    [actionTypes.exploding]:()=>{
+      console.log('exploding')
+    },
     [actionTypes.favor]:()=>null,
     [actionTypes.multiple2]:()=>null,
     [actionTypes.multiple3]:()=>null,
@@ -25,7 +84,7 @@ type ActionImpl =  {
     [actionTypes.shuffle]:()=>{
       console.log('shuffle')
     },
-    [actionTypes.skip]:()=>null,
+    [actionTypes.skip]:()=>null
   }
 
   return actions

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -43,8 +43,8 @@ export const useGameActions = ()=>{
   return actions
 }
 
-type useCardActionsProps = {initListeners:boolean}
-export const useCardActions = ({initListeners}:useCardActionsProps={initListeners:false})=>{
+
+export const useCardActions = ()=>{
   const { setCurrentActions,currentActions,setActionPrompt,socket,turnCount} = useGameStateContext() || {}
   const {players,currentPlayerUsername} = usePlayerContext() || {}
   const [actionsComplete,setActionsComplete]=useState<number>(0)
@@ -58,11 +58,11 @@ export const useCardActions = ({initListeners}:useCardActionsProps={initListener
 
   const diffuseAction = () =>{
     //only activate if turn player
-    console.log('activate diffuse')
     if(setCurrentActions) setCurrentActions(
       prev=>prev.filter(prev=>prev!==cardTypes.exploding.type)
     )
     setActionsComplete(prev=>prev+1)
+    console.log('diffuse')
   }
 
   const submitResponseEvent = (
@@ -72,7 +72,6 @@ export const useCardActions = ({initListeners}:useCardActionsProps={initListener
   )=>{
     socket?.emit('next-action-response',{
       showToUser,
-      customOptions,
       ...(customOptions?{customOptions}:{}),
       complete
     })
@@ -118,11 +117,11 @@ export const useCardActions = ({initListeners}:useCardActionsProps={initListener
               const playersCopy = [...players ?? []]
               playersCopy[currentPlayerIndex].cards = newCurrentPlayerHand
               playersCopy[turnPlayerIndex].cards = newTurnPlayerHand
-              console.log('COPY!!!',playersCopy)
 
               socket?.emit('all-players',playersCopy)
               setActionPrompt(null)
               submitResponseEvent('',{},true)
+              setActionsComplete(prev=>prev+1)
             }
           }
         ]

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -67,7 +67,7 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
   const [allowedResponse, setAllowedResponse] = useState<ResponseActions | null | "all">("all")
   const [allowedUsers, setAllowedUsers] = useState<string[]>([])
 
-  const {actions,setActionsComplete,actionsComplete} = useCardActions({initListeners:true})
+  const {actions,setActionsComplete,actionsComplete} = useCardActions()
 
   //when all users respond with "no responses", perform all actions in currentActions stack
   //this will mostly be a bunch of nopes cancelling each other out and on other action at the bottom

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -56,6 +56,7 @@ export const usePlayerSocket=()=>{
     clearPlayers
   }
 }
+
 type useActivateResponseHandlersProps = {initListeners:boolean}
 export const useActivateResponseHandlers=({initListeners}:useActivateResponseHandlersProps={initListeners:false})=>{
 
@@ -66,7 +67,7 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
   const [allowedResponse, setAllowedResponse] = useState<ResponseActions | null | "all">("all")
   const [allowedUsers, setAllowedUsers] = useState<string[]>([])
 
-  const actionsImpl = useCardActions()
+  const {actions,setActionsComplete,actionsComplete} = useCardActions({initListeners:true})
 
   //when all users respond with "no responses", perform all actions in currentActions stack
   //this will mostly be a bunch of nopes cancelling each other out and on other action at the bottom
@@ -81,7 +82,7 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
       if(setCurrentActions)setCurrentActions(prev=>prev.slice(0,prev.length-1))
 
       //implement action
-      actionsImpl[currentActions[currentActions.length-1]]()
+      actions[currentActions[currentActions.length-1]]()
 
       //reset allowed users, responses, and hide response prompt
       setShowResponsePrompt(false)
@@ -94,9 +95,10 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
     
     if(!currentActions?.length){
       setNoResponses(0)
+      setActionsComplete(0)
     }
     //shouldn't listen for global state data
-  },[noResponses,currentActions?.length])
+  },[noResponses,actionsComplete,allowedUsers?.length])
 
 
   useEffect(()=>{
@@ -105,7 +107,7 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
     socket?.on('activate-attempt',(data)=>{
       if(
         !setCurrentActions
-        || ((allowedResponse!==data.action) && allowedResponse!=="all")
+        || ((data.allowedResponse!==data.action) && data.allowedResponse!=="all")
       ) return
 
       setCurrentActions(prev=>[...prev,data.action])

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -183,7 +183,6 @@ export const useActivateResponseHandlers=({initListeners}:useActivateResponseHan
 export const useInitGame = () => {
   const {setDeck,socket} = useGameStateContext() || {}
   const {players} = usePlayerContext() || {}
-  const {setPlayerHand} = useGameActions()
 
   const excludedCardTypes:CardType[] = [cardTypes.exploding.type,cardTypes.diffuse.type]
   const handSize = 5

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -24,6 +24,13 @@ declare global{
     lose: boolean
     cards: Card[]
   }
+  type ActionPromptData = {
+    show: boolean
+    options:{
+      [key:string]:any[]
+    }
+    submitCallBack: Function
+  }
   //socket.io event types
   interface ServerToClientEvents {
     ['new-page-backend']: (arg:{message:string}) => void

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -47,6 +47,11 @@ declare global{
     }) => void
     ['all-players']: (arg:Player[]) => void
     ['deck']: (arg:Card[]) => void
+    ['next-action-response']: (arg:{
+      showToUser:string
+      customOptions?:ActionPromptData["options"]
+      complete:boolean
+    }) => void
   }
   
   interface ClientToServerEvents {
@@ -63,5 +68,10 @@ declare global{
     ['no-response']: () => void
     ['clear-players']: () => void
     ['deck']: (arg:Card[]) => void
+    ['next-action-response']: (arg:{
+      showToUser:string
+      customOptions?:ActionPromptData["options"]
+      complete:boolean
+    }) => void
   }
 }

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -1,8 +1,8 @@
-import { actionTypes } from "@/data/index"
-import { cardTypes } from "@/data/index"
 export {}
 
 declare global{
+  type cardTypesConst = typeof import('../data/index').cardTypes
+  type actionTypesConst = typeof import('../data/index').actionTypes
   type User = {
     wins?: number
     rooms?: []
@@ -10,14 +10,14 @@ declare global{
     id?: number
     username?: string
   }
-  type CardType = typeof cardTypes[keyof typeof cardTypes]["type"]
+  type CardType = cardTypesConst[keyof cardTypesConst]["type"]
   type Card = {
     id:number
     color: string
     image: string
     type: CardType
   }
-  type Actions = typeof actionTypes[keyof typeof actionTypes]
+  type Actions = actionTypesConst[keyof actionTypesConst]
   type ResponseActions = Actions["nope"] | Actions["diffuse"]
   type Player = {
     username: string


### PR DESCRIPTION
# Description
- Added new `useTurns` hook that returns a `endTurn` function that draws a card, and handles case with exploding kitten
- updated `useActivateResponseHandlers` to have a `initListeners` param that's set to false on default so listeners aren't double initialized
- added new ActionPrompt context on the gameStateContext. This is an array of options for a select element and a submit function. This will be the data needed for the actions that need parameters for the action like "Favor". When this is set, each data set will show a prompt and when one is complete, it'll run through the next in the list. This is displayed in the new `ActionPrompt` component. `favorAction` is an example of how this works.

Think I may have gotten a little too deep into the solution here, so if there's something simpler, let me know!