### PR TITLE
Rooms and attack/ see the future actions

### DIFF
--- a/backend/helpers/index.js
+++ b/backend/helpers/index.js
@@ -3,3 +3,16 @@ export const generateRoutes = (routesPathMap,app)=>{
     app.use(routePath,routeView)
   })
 }
+
+export const emitToPlayerRoom = (io,socket,event,data,customErrorMessage)=>{
+  if(io || !socket || !event || !data){
+    console.log('missing data',[io,socket,event,data])
+  }
+  const playerRoom = Array.from(socket.rooms)[1]
+  if(!playerRoom){
+    socket.emit('error',{
+      message: customErrorMessage ?? 'no room found for player'
+    })
+  }
+  io.to(playerRoom).emit(event,data)
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -40,14 +40,10 @@ db.once('connected', () => {
   console.log('DB connected')
 })
 
-let players = []
-let deck = []
-
 let rooms = {}
 
 io.on('connection', (socket) => {
   console.log('a player connected',socket.id);
-  socket.emit('all-players',players)
   socket.on('disconnecting', () => {
     const playerRoom = Array.from(socket.rooms)[1]
     if(rooms[playerRoom]){
@@ -113,25 +109,22 @@ io.on('connection', (socket) => {
     if(rooms[playerRoom]){
       rooms[playerRoom].players = []
     }
-    emitToPlayerRoom(io,socket,'all-players', players)
+    emitToPlayerRoom(io,socket,'all-players', rooms[playerRoom].players)
   })
 
   socket.on('activate-attempt',(data)=>{
     console.log('activate-attempt',data)
     emitToPlayerRoom(io,socket,'activate-attempt', data)
-    // io.sockets.emit('activate-attempt',data)
   })
 
   socket.on('no-response',()=>{
     console.log('no-response')
     emitToPlayerRoom(io,socket,'no-response')
-    // io.sockets.emit('no-response')
   })
 
   socket.on('next-action-response',(data)=>{
     console.log('next-action-response',data)
     emitToPlayerRoom(io,socket,'next-action-response', data)
-    // io.sockets.emit('next-action-response',data)
   })
 });
 

--- a/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
@@ -39,10 +39,11 @@ export const ActionPrompt = ()=>{
       const formData = new FormData(e.currentTarget)
       currentActionPrompt?.submitCallBack(formData)
     }}>
+      <p className="action-prompt-text">{currentActionPrompt?.text}</p>
       {Object.entries(currentActionPrompt?.options ?? {}).map(([name,options])=>(
         <select key={`select-${name}`} name={name}>
           {options?.map(option=>(
-            <option key={`option-${option}`} value={option}>{option}</option>
+            <option key={`option-${option.value}`} value={option.value}>{option.display}</option>
           ))}
         </select>
       ))}
@@ -50,12 +51,12 @@ export const ActionPrompt = ()=>{
       {Object.entries(customOptions ?? {}).map(([name,options])=>(
         <select key={`select-${name}`} name={name}>
           {options?.map(option=>(
-            <option key={`option-${option}`} value={option}>{option}</option>
+            <option key={`option-${option.value}`} value={option.value}>{option.display}</option>
           ))}
         </select>
       ))}
 
-      <button type="submit" className="btn btn-blue">Submit Action Response</button>
+      <button type="submit" className="btn btn-blue">Submit/Confirm</button>
     </form>
   )
 

--- a/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
@@ -7,7 +7,7 @@ export const Hand = ()=>{
   <div className="flex flex-wrap">
     hand:
     {currentCards?.map(card=>(
-      <div className="hand-card border border-black w-[10rem] break-words" key={card.id}>
+      <div className="hand-card border border-black w-[10rem] break-words" key={card?.id}>
         {JSON.stringify(card)}
       </div>
     ))}

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -21,7 +21,7 @@ type RoomParams = {
 
 const Room = ({params}:RoomParams)=>{
   const playerContext = usePlayerContext()
-  const {socket,deck, turnCount} = useGameStateContext() || {}
+  const {socket,deck, turnCount, attackTurns} = useGameStateContext() || {}
 
   const [users,setUsers] = useState<User | null>(null)
   const [username,setUsername] = useState<string>("")
@@ -79,6 +79,12 @@ const Room = ({params}:RoomParams)=>{
         <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.favor)}>
           favor
         </button>
+        <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.seeTheFuture)}>
+          send see the future
+        </button>
+        <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.attack)}>
+          attack
+        </button>
         {showResponsePrompt && (
           <div>
           <button className="btn btn-blue" onClick={()=>attemptActivate(actionTypes.nope)}>
@@ -133,7 +139,7 @@ const Room = ({params}:RoomParams)=>{
         </button>
       </div>
       <div className="border border-black">
-        <h1>{turnCount}</h1>
+        <h1>turn count: {turnCount}, attack turns: {attackTurns}</h1>
         <button className="btn btn-blue" onClick={()=>endTurn()}>
           end turn
         </button>

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -41,23 +41,6 @@ const Room = ({params}:RoomParams)=>{
   const {endTurn} = useTurns()
 
   useEffect(()=>{
-    //preSocketRef.current makes sure we don't double add listeners
-    //can make this a helper hook to reduce boilerplate
-    socket?.emit('new-page',{
-      message:'new page!!'
-    })
-
-    socket?.on('new-page-backend',(data:{
-      message:string
-    })=>{
-      console.log('new-page-backend!!',data)
-    })
-    return () => {
-      socket?.disconnect();
-    }
-  },[socket])
-
-  useEffect(()=>{
     //add to .env
     fetch('http://localhost:3000/users')
       .then((res)=>res.json())
@@ -105,7 +88,7 @@ const Room = ({params}:RoomParams)=>{
         <h1>join room</h1>
         <form onSubmit={(e:React.FormEvent)=>{
           e.preventDefault()
-          joinRoom(username)
+          joinRoom(username,params.roomNumber)
           setUsername("")
         }}>
           <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="username">

--- a/exploding-kittens-frontend/src/context/gameState.tsx
+++ b/exploding-kittens-frontend/src/context/gameState.tsx
@@ -8,8 +8,10 @@ type GameStateContextValues ={
   turnCount: number,
   currentActions:Actions[],
   actionPrompt: ActionPromptData[] | null,
+  attackTurns: number,
   socket:Socket<ServerToClientEvents, ClientToServerEvents> | null,
   setSocket: React.Dispatch<React.SetStateAction<Socket<ServerToClientEvents, ClientToServerEvents> | null>>,
+  setAttackTurns: React.Dispatch<React.SetStateAction<number>>
   setActionPrompt: React.Dispatch<React.SetStateAction<ActionPromptData[] | null>>
   setDeck: React.Dispatch<React.SetStateAction<Card[]>>
   setDiscardPile: React.Dispatch<React.SetStateAction<Card[]>>
@@ -27,6 +29,7 @@ export const GameStateContextProvider = ({children}:{
   const [turnCount, setTurnCount]= useState<number>(0)
   const [currentActions, setCurrentActions]= useState<Actions[]>([])
   const [actionPrompt, setActionPrompt]= useState<ActionPromptData[] | null>(null)
+  const [attackTurns, setAttackTurns]= useState<number>(0)
   const [socket, setSocket]= useState<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null)
 
   return (
@@ -38,6 +41,8 @@ export const GameStateContextProvider = ({children}:{
         currentActions,
         socket,
         actionPrompt,
+        attackTurns,
+        setAttackTurns,
         setActionPrompt,
         setSocket,
         setDeck,

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -282,7 +282,9 @@ export const useInitGame = () => {
 export const useTurns = ()=>{
   const {
     turnCount,
+    attackTurns,
     setTurnCount,
+    setAttackTurns
   } = useGameStateContext() || {}
   const {currentPlayer,players} = usePlayerContext() ||{}
 
@@ -293,13 +295,17 @@ export const useTurns = ()=>{
   useEffect(()=>{
     //move up turn count at end of action chain in case of exploding cat and diffuse
     if(!currentActions?.length && isTurnEnd){
-      if(setTurnCount)setTurnCount(prev=>prev+1)
+      if(attackTurns??0>0){
+        if(setAttackTurns)setAttackTurns(prev=>prev-1)
+      }else{
+        if(setTurnCount)setTurnCount(prev=>prev+1)
+      }
     }
   },[currentActions?.length])
 
   useEffect(()=>{
     setIsTurnEnd(false)
-  },[turnCount])
+  },[turnCount,attackTurns])
 
 
   const endTurn = () =>{
@@ -308,7 +314,11 @@ export const useTurns = ()=>{
     if(newCard?.type === cardTypes.exploding.type){
       attemptActivate(cardTypes.exploding.type)
     }else{
-      if(setTurnCount)setTurnCount(prev=>prev+1)
+      if(attackTurns??0>0){
+        if(setAttackTurns)setAttackTurns(prev=>prev-1)
+      }else{
+        if(setTurnCount)setTurnCount(prev=>prev+1)
+      }
     }
   }
 

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -26,8 +26,9 @@ declare global{
   }
   type ActionPromptData = {
     show: boolean
+    text?:string
     options:{
-      [key:string]:any[]
+      [key:string]:{value:string,display:string}[]
     }
     submitCallBack: Function
   }


### PR DESCRIPTION
# description
- added implementation for `see-the-future` action
- added a field on action prompt for just a text string(for see the future)
- added implementation for `attack` action
- added new room object on the backend to store all data, for all rooms and use new method io.to('room string').emit() to send data to only certain rooms. Also updated `new-player` backend listener and `disconnecting` listener to add and remove players from rooms
- added new emitToPlayerRoom helper function that emits events to the room that the sender is in