### PR TITLE
Login Logic

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -3,19 +3,24 @@ import User from '../models/User.js'
 
 const login = async (req, res) => {
   try {
-    const { username, password } = req.body
+    const _username = req.body.username
+    const password = req.body.password
 
-    const existingUser = await User.findOne({username})
+    const existingUser = await User.findOne({username: _username})
 
     if (!existingUser) {
-      return res.json({error: `no user with name ${username} exists in our system`})
+      return res.json({error: `no user with name ${_username} exists in our system`})
     } 
 
-    if (bcrypt.compare(existingUser.password, password)) {
-      const { username, rooms, wins, id, _id } = existingUser
-      return res.json({username, rooms, wins, id, _id}).status(200)
+    const passMatch = await bcrypt.compare(password, existingUser.password)
+    
+    if (!passMatch) {
+      return res.json({error: 'incorrect password'})
     }
-
+    
+    const { username, rooms, wins, id, _id } = existingUser
+    return res.json({username, rooms, wins, id, _id}).status(200)
+    // need to set up error handling from back -> frontend
   } catch (e) {
     res.json({ error: `error logging in ${e}`})
   }

--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -12,8 +12,8 @@ const login = async (req, res) => {
     } 
 
     if (bcrypt.compare(existingUser.password, password)) {
-      console.log(username, password)
-      res.json({existingUser}).status(200)
+      const { username, rooms, wins, id, _id } = existingUser
+      return res.json({username, rooms, wins, id, _id}).status(200)
     }
 
   } catch (e) {

--- a/exploding-kittens-frontend/src/app/auth/login/page.tsx
+++ b/exploding-kittens-frontend/src/app/auth/login/page.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useState } from 'react'
+import { usePlayerContext } from '@/context/players'
 
 const Login = () => {
+  const { setCurrentPlayer, currentPlayer } = usePlayerContext() || {}
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
@@ -20,14 +22,13 @@ const Login = () => {
       })
       .then(res => res.json())
       .then((data: User) => {
-        console.log("data:",data)
+        if (setCurrentPlayer) setCurrentPlayer(data)
       })
-
+    
     } catch (error) {
       console.error('Error during login:', error);
     }
   }
-
   return (
     <div>
       <h2>Login</h2>

--- a/exploding-kittens-frontend/src/app/auth/login/page.tsx
+++ b/exploding-kittens-frontend/src/app/auth/login/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { usePlayerContext } from '@/context/players'
 
 const Login = () => {
-  const { setCurrentPlayer, currentPlayer } = usePlayerContext() || {}
+  const router = useRouter()
+  const { setCurrentPlayer } = usePlayerContext() || {}
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
@@ -22,9 +24,11 @@ const Login = () => {
       })
       .then(res => res.json())
       .then((data: User) => {
-        if (setCurrentPlayer) setCurrentPlayer(data)
+        if (setCurrentPlayer && data.username) {
+          setCurrentPlayer(data)
+          router.push('/')
+        }
       })
-    
     } catch (error) {
       console.error('Error during login:', error);
     }


### PR DESCRIPTION
Backend
- in login route, assigned username from req.body.username to _username to avoid naming conflict/confusion further down
- fixed bcrypt.compare() call to have hashed and unhashed passwords in the correct order
- successful login will now send {username, rooms, wins...} instead of {existingUser: {username, room, wins...} 

Frontend
- successful login now sets currentPlayer context
- added router logic to redirect to home page ('/' route) after successful login attempt
- added the condition of data.username before setting currentPlayer context to make sure we don't set it to anything other than a User object or null:

We are sending {error: ...} objects from the backend when either a password doesn't match or a user isn't found, will probably need to adjust this approach. Onward to error handling from here!
