### PR TITLE
Save player on global object

### DIFF
--- a/backend/helpers/index.js
+++ b/backend/helpers/index.js
@@ -5,7 +5,7 @@ export const generateRoutes = (routesPathMap,app)=>{
 }
 
 export const emitToPlayerRoom = (io,socket,event,emitData,customErrorMessage)=>{
-  if(io || !socket || !event || !emitData){
+  if(!io || !socket || !event || !emitData){
     console.log('missing data io, socket, event, data',[!io, !socket, !event, !emitData])
   }
   const playerRoom = Array.from(socket.rooms)[1]

--- a/backend/index.js
+++ b/backend/index.js
@@ -41,7 +41,8 @@ db.once('connected', () => {
 })
 
 const roomMax = 4
-const disconnectTimeout = 10000
+//set for 10 min
+const disconnectTimeout = 1000 * 60 * 10
 const timeoutIds = {}
 
 let rooms = {}
@@ -136,6 +137,7 @@ io.on('connection', (socket) => {
       lose:false,
       cards:[]
     })
+    console.log('ROOM!!',rooms[data.room]?.players)
     emitToPlayerRoom(io,socket,'all-players',rooms[data.room]?.players ?? [])
   })
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -63,13 +63,13 @@ io.on('connection', (socket) => {
         player=>player.socketId===socket.id
       )
       if(playerDisconncted){
-        timeoutIds[playerDisconncted.username] = setTimeout(()=>{
+        timeoutIds[playerDisconncted.username] = setTimeout((allRooms)=>{
           console.log('timeout hit')
-          rooms[playerRoomNumber].players = rooms[playerRoomNumber]?.players?.filter(
+          allRooms[playerRoomNumber].players = allRooms[playerRoomNumber]?.players?.filter(
             player=>player.socketId!==socket.id
           )
-          io.sockets.emit('all-players',rooms[playerRoomNumber].players ?? [])
-        },disconnectTimeout)
+          io.sockets.emit('all-players',allRooms[playerRoomNumber].players ?? [])
+        },disconnectTimeout,rooms)
       }
       console.log('a player disconnected',socket.id,rooms[playerRoomNumber]);
       io.sockets.emit('all-players',rooms[playerRoomNumber].players ?? [])

--- a/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
@@ -1,0 +1,27 @@
+import { usePlayerContext } from "@/context/players";
+
+const OtherPlayers = ()=>{
+  const {players} = usePlayerContext() || {}
+
+  return(
+    <div>
+      Other Players
+      {players?.map(player=>(
+        <div className="border border-black">
+          <div className="flex items-center">
+          {player.username}:&nbsp;
+          {player?.active?
+            <div className="rounded-full bg-green-400 h-3 w-3"/>
+            :<div className="rounded-full border-2 border-grey-500 bg-grey-100 h-3 w-3"/>
+          }
+          </div>
+          <div>
+            number of cards: {player?.cards?.length ?? 0}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default OtherPlayers

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -7,6 +7,7 @@ import {
   usePlayerSocket 
 } from "@/lib/hooks"
 import Hand from "@/app/[roomNumber]/hand"
+import OtherPlayers from "@/app/[roomNumber]/OtherPlayers"
 
 
 type RoomParams = {
@@ -66,7 +67,7 @@ const Room = ({params}:RoomParams)=>{
             clear players
         </button>
       </div>
-
+      <OtherPlayers/>
       <div className="border border-black">
         <Hand/>
         <div className="h-[15rem] overflow-y-scroll">

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -97,8 +97,8 @@ export const useGameActions = ()=>{
       if(!cardInActions)return false
 
       const singleCardActionType = Object.keys(singleCardActionRequirements)
-        .find(aType=>aType===selectedCards[0].type) as keyof typeof singleCardActionRequirements
-
+      .find(aType=>aType===selectedCards[0].type) as keyof typeof singleCardActionRequirements
+      
       if(singleCardActionType){
         return singleCardActionRequirements[singleCardActionType]()
       }
@@ -111,6 +111,7 @@ export const useGameActions = ()=>{
     }
     return true
   }
+
 
   const validResponseCards = useMemo(()=>playerCards?.filter(card=>(
     responseActionsTypes.includes(card.type as typeof responseActionsTypes[number])

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -113,9 +113,9 @@ export const useActivateResponseHandlers=({initListeners}:UseActivateResponseHan
 
       if(data.newAllowedUsers.includes(currentPlayer.username || '')){
         setShowResponsePrompt(true)
-      }else(
+      }else{
         setShowResponsePrompt(false)
-      )
+      }
 
       //set response restrictions
       setAllowedUsers(data.newAllowedUsers)

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -21,6 +21,7 @@ declare global{
   type ResponseActions = Actions["nope"] | Actions["diffuse"]
   type Player = {
     username: string
+    active: boolean,
     lose: boolean
     cards: Card[]
   }


### PR DESCRIPTION
# Description
- Updated `Rooms[rooms number].players` to have an `active` property that's added to the `new-player` event. This will be set to false on disconnect and set to true again if a user with the same username is added via the `new-player` event.
- If the `new-player` event fires with a user that is inactive, the player will get all the deck, discard-pile, and player data
- Added a timeout function and a global timeoutIds object to store all of them. After 10 minutes of disconnect of a player username, the player data will be deleted. If a player reconnects with the same username, the timeout will be cleared.
- added a component `OtherPlayers` to show which players are connected and card count.
