### PR TITLE
Remaining Card Actions and Action Prompts refactor

### DIFF
--- a/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
@@ -25,6 +25,7 @@ const ActionPrompt = ()=>{
     socket?.on('next-action-response',(data)=>{
       if(data.customOptions)setCustomOptions(data.customOptions)
       if(data.customText)setCustomText(data.customText)
+      //setCustomResponse
       setShowToUser(data.showToUser)
       setResponseCount(prev=>prev+1)
       if(data.complete){

--- a/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/ActionPrompt.tsx
@@ -66,8 +66,8 @@ const ActionPrompt = ()=>{
             <React.Fragment key={`options-${name}`}>
               <label htmlFor={name}>{name}:</label>
               <select id={name} name={name}>
-                {options?.map(option=>(
-                  <option key={`option-${option.value}`} value={option.value}>{option.display}</option>
+                {options?.map((option,idx)=>(
+                  <option key={`option-${option.value}-${idx}`} value={option.value}>{option.display}</option>
                 ))}
               </select>
             </React.Fragment>

--- a/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
@@ -7,7 +7,7 @@ const OtherPlayers = ()=>{
     <div>
       Other Players
       {players?.map(player=>(
-        <div className="border border-black">
+        <div className="border border-black" key={player.username}>
           <div className="flex items-center">
           {player.username}:&nbsp;
           {player?.active?

--- a/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/hand.tsx
@@ -2,7 +2,7 @@ import { usePlayerContext } from "@/context/players"
 import { useGameStateContext } from "@/context/gameState"
 import { useActivateResponseHandlers, useTurns } from "@/lib/hooks"
 import { useGameActions } from "@/lib/actions"
-import { useState, useEffect,lazy, Suspense } from "react"
+import { useState, useEffect,lazy, Suspense,memo } from "react"
 import classNames from 'classnames'
 import { actionTypes } from "@/data"
 
@@ -21,7 +21,7 @@ const multiCardActions:MultiCardActionsType = {
 
 const Hand = ()=>{
   const {players,currentPlayer} =  usePlayerContext() || {}
-  const {socket,turnCount} =  useGameStateContext() || {}
+  const {socket,turnCount,attackTurns} =  useGameStateContext() || {}
   const [selectedCards,setSelectedCards]=useState<Card[]>([])
   const [allowedResponseUsers,setAllowedResponseUsers] = useState<string[]>([])
   const {endTurn, turnPlayer, isTurnEnd} = useTurns({initListeners:true})
@@ -105,6 +105,7 @@ const Hand = ()=>{
     </div>
     <div className="border border-black">
       <p>turn count: {turnCount}</p>
+      <p>attack: {attackTurns}</p>
       <p>turn player: {turnPlayer?.username}</p>
       <button className="btn btn-blue" onClick={cardActivateHandler} disabled={disableActions}>
         activate card(s)
@@ -123,4 +124,4 @@ const Hand = ()=>{
   )
 }
 
-export default Hand
+export default memo(Hand)

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -4,7 +4,8 @@ import { usePlayerContext } from "@/context/players"
 import { useGameStateContext } from "@/context/gameState"
 import {
   useInitGame,
-  usePlayerSocket 
+  usePlayerSocket ,
+  useTurns
 } from "@/lib/hooks"
 import Hand from "@/app/[roomNumber]/hand"
 import OtherPlayers from "@/app/[roomNumber]/OtherPlayers"
@@ -17,8 +18,9 @@ type RoomParams = {
 }
 
 const Room = ({params}:RoomParams)=>{
-  const playerContext = usePlayerContext()
+  const playerContext = usePlayerContext() || {}
   const {deck,discardPile} = useGameStateContext() || {}
+  useTurns() || {}
 
   const [users,setUsers] = useState<User | null>(null)
   const [username,setUsername] = useState<string>("")

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -20,7 +20,7 @@ type RoomParams = {
 const Room = ({params}:RoomParams)=>{
   const playerContext = usePlayerContext() || {}
   const {deck,discardPile} = useGameStateContext() || {}
-  useTurns() || {}
+  const {winner} = useTurns() || {}
 
   const [users,setUsers] = useState<User | null>(null)
   const [username,setUsername] = useState<string>("")
@@ -40,6 +40,7 @@ const Room = ({params}:RoomParams)=>{
 
   return (
     <div className="w-full">
+      {winner && <div>Game Over! winner is: {winner.username}</div>}
       Room Number: {params.roomNumber}
       {JSON.stringify(playerContext)}
       {JSON.stringify(users)}

--- a/exploding-kittens-frontend/src/context/gameState.tsx
+++ b/exploding-kittens-frontend/src/context/gameState.tsx
@@ -7,12 +7,12 @@ type GameStateContextValues ={
   discardPile: Card[],
   turnCount: number,
   currentActions:Actions[],
-  actionPrompt: ActionPromptData[] | null,
+  actionPrompt: ((previousAnswerObject?:{[key:string]: any})=>ActionPromptData)[] | null,
   attackTurns: number,
   socket:Socket<ServerToClientEvents, ClientToServerEvents> | null,
   setSocket: React.Dispatch<React.SetStateAction<Socket<ServerToClientEvents, ClientToServerEvents> | null>>,
   setAttackTurns: React.Dispatch<React.SetStateAction<number>>
-  setActionPrompt: React.Dispatch<React.SetStateAction<ActionPromptData[] | null>>
+  setActionPrompt: React.Dispatch<React.SetStateAction<((previousAnswerObject?:{[key:string]: any})=>ActionPromptData)[] | null>>
   setDeck: React.Dispatch<React.SetStateAction<Card[]>>
   setDiscardPile: React.Dispatch<React.SetStateAction<Card[]>>
   setTurnCount: React.Dispatch<React.SetStateAction<number>>
@@ -28,7 +28,7 @@ export const GameStateContextProvider = ({children}:{
   const [discardPile, setDiscardPile]= useState<Card[]>([])
   const [turnCount, setTurnCount]= useState<number>(0)
   const [currentActions, setCurrentActions]= useState<Actions[]>([])
-  const [actionPrompt, setActionPrompt]= useState<ActionPromptData[] | null>(null)
+  const [actionPrompt, setActionPrompt]= useState<((previousAnswerObject?:{[key:string]: any})=>ActionPromptData)[] | null>(null)
   const [attackTurns, setAttackTurns]= useState<number>(0)
   const [socket, setSocket]= useState<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null)
 

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -248,8 +248,7 @@ export const useCardActions = ()=>{
           },
           submitCallBack:(formData:FormData)=>{
             const playerSelectedUsername = formData?.get('username')?.toString()
-            console.log('CALLBACK',playerSelectedUsername)
-            const selectedPlayerIndex = players?.findIndex(p=>p.username==playerSelectedUsername)
+            const selectedPlayerIndex = players?.findIndex(p=>p.username==currentPlayer?.username)
             if(!selectedPlayerIndex && selectedPlayerIndex!==0){
               console.error('current player index not found')
               return
@@ -257,7 +256,6 @@ export const useCardActions = ()=>{
 
             const cardsShuffled = shuffleArray(players?.[selectedPlayerIndex].cards ?? [])
             const newCard = cardsShuffled[0]
-            console.log('NEW CARD',newCard)
             
             removeCardsFromHand(socket,[...(newCard?[newCard]:[])],playerSelectedUsername,players)
             addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)

--- a/exploding-kittens-frontend/src/lib/actions.ts
+++ b/exploding-kittens-frontend/src/lib/actions.ts
@@ -130,7 +130,6 @@ export const useGameActions = ()=>{
   return actions
 }
 
-
 //probably should seperate each impl into it's own file eventually
 export const useCardActions = ()=>{
   const { 
@@ -138,6 +137,7 @@ export const useCardActions = ()=>{
     discardPile,
     socket,
     turnCount,
+    attackTurns,
     setCurrentActions,
     setActionPrompt,
     setAttackTurns,
@@ -152,23 +152,193 @@ export const useCardActions = ()=>{
 
   //this needs to be added on each submitCallBack to trigger the next event
   //or complete the event chain
-  const submitResponseEvent = (
-    showToUser:string,
-    customOptions:ActionPromptData["options"]={},
-    customText:string='',
-    complete:boolean=false
-  )=>{
+  type SubmitResponseEventProps = {
+    formData?:FormData,
+    complete?:boolean,
+  }
+  const submitResponseEvent = ({
+    formData,
+    complete=false,
+  }:SubmitResponseEventProps={})=>{
+
+    const formObject = Object.fromEntries(formData?.entries() ?? []);
     socket?.emit('next-action-response',{
-      showToUser,
-      ...(customOptions?{customOptions}:{}),
-      ...(customText?{customText}:{}),
-      complete
+      formObject,
+      complete,
     })
     if(complete && setActionPrompt) {
       setActionPrompt(null)
       setActionsComplete(prev=>prev+1)
     }
   }
+
+  const diffuseActionPrompts = [
+    ()=>({
+      showToUser:turnPlayer.username,
+      text:'choose a position to put the card back in. 0 is on top',
+      options:{
+        ['deck-placement']:(deck ?? []).map((_,index)=>({
+          value:index,
+          display:index
+        }))
+      },
+      submitCallBack:(formData:FormData)=>{
+        const deckPlacement = formData?.get('deck-placement')?.toString()
+        if(!deckPlacement){
+          console.log('error: no deck placement found')
+          return
+        }
+        if(!deck){
+          console.log('error: deck not found')
+          return
+        }
+        const discardedExploding = discardPile?.find(card=>card.type===actionTypes.exploding)
+        if(!discardedExploding){
+          console.log('error: no exploding card found')
+          return
+        }
+        const newDeck = [...deck ?? []]
+        newDeck.splice(deck.length - parseInt(deckPlacement),0,discardedExploding)
+        socket?.emit('deck',newDeck)
+        socket?.emit('discard-pile',discardPile?.filter(c=>c.id!==discardedExploding.id) || [])
+        submitResponseEvent({complete:true})
+      }
+    }),
+  ]
+
+  const favorActionPrompts = [
+    ()=>({
+      showToUser:turnPlayer.username,
+      text:'Choose a player to steal a card from',
+      options:{
+        username:[...players
+        ?.filter(p=>p.username!==currentPlayer?.username)
+        ?.map(p=>({
+          value:p.username,
+          display:p.username
+        }))??[]]
+      },
+      submitCallBack:(formData:FormData)=>{
+        submitResponseEvent({formData})
+      }
+    }),
+    (previousAnswerObject?:{[key:string]: any})=>({
+      showToUser:previousAnswerObject?.username,
+      text:'Choose a card to give away',
+      options:{
+        card:players?.find(p=>p.username===previousAnswerObject?.username)?.cards?.map(c=>({
+          value:c.type,
+          display:`${c.type} - ${c.id}`
+        })) ?? []
+      },
+      submitCallBack:(formData:FormData)=>{
+        const cardType = formData.get('card')
+
+        const currentPlayerIndex = players?.findIndex(p=>p.username==currentPlayer?.username)
+        if(!currentPlayerIndex && currentPlayerIndex!==0){
+          console.error('current player index not found')
+          return
+        }
+
+        const newCard = players?.[currentPlayerIndex]
+          ?.cards
+          ?.find(c=>c.type===cardType)
+        
+        removeCardsFromHand(socket,[...(newCard?[newCard]:[])],currentPlayer?.username,players)
+        addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
+
+        submitResponseEvent({complete:true})
+      }
+    })
+  ]
+
+  const multiple2ActionPrompts = [
+    ()=>({
+        showToUser:turnPlayer.username,
+        text:'Choose a player to steal a card from',
+        options:{
+          username:[...players
+          ?.filter(p=>p.username!==currentPlayer?.username)
+          ?.map(p=>({
+            value:p.username,
+            display:p.username
+          }))??[]]
+        },
+        submitCallBack:(formData:FormData)=>{
+          const playerSelectedUsername = formData?.get('username')?.toString()
+          const selectedPlayerIndex = players?.findIndex(p=>p.username==currentPlayer?.username)
+          if(!selectedPlayerIndex && selectedPlayerIndex!==0){
+            console.error('current player index not found')
+            return
+          }
+
+          const cardsShuffled = shuffleArray(players?.[selectedPlayerIndex].cards ?? [])
+          const newCard = cardsShuffled[0]
+          
+          removeCardsFromHand(socket,[...(newCard?[newCard]:[])],playerSelectedUsername,players)
+          addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
+          
+          submitResponseEvent({complete:true})
+        }
+      }),
+    ]
+  
+  const multiple3ActionPrompts = [
+    ()=>({
+      showToUser:turnPlayer.username,
+      text:'Choose a player to steal from and a card type',
+      options:{
+        username:[...players
+        ?.filter(p=>p.username!==currentPlayer?.username)
+        ?.map(p=>({
+          value:p.username,
+          display:p.username
+        }))??[]],
+        card:Object.values(cardTypes).map(card=>({
+          value:card.type,
+          display:card.type
+        }))
+      },
+      submitCallBack:(formData:FormData)=>{
+        const playerSelectedUsername = formData?.get('username')?.toString()
+        const cardTypeSelected = formData?.get('card')?.toString()
+        
+        const newCard = players?.find(p=>p.username === playerSelectedUsername)
+          ?.cards?.find(card=>card.type===cardTypeSelected)
+        
+        if(!newCard){
+          submitResponseEvent({})
+          return
+        }
+
+        removeCardsFromHand(socket,[...(newCard?[newCard]:[])],playerSelectedUsername,players)
+        addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
+        
+        submitResponseEvent({complete:true})
+      }
+    }),
+    ()=>({
+      showToUser:turnPlayer.username,
+      text:'Card is Not Found',
+      options:{},
+      submitCallBack:()=>{
+        submitResponseEvent({complete:true})
+      }
+    })
+  ]
+
+  const seeTheFutureActionPrompts = [
+    ()=>({
+      showToUser:turnPlayer.username,
+      text:`the next 3 cards are: ${deck?.slice(deck.length-3).map(
+        c=>`${c.type} - ${c.id}`
+      ).join()}`,
+      options:{},
+      submitCallBack:()=>{
+        submitResponseEvent({complete:true})
+      }
+    }),
+  ]
   
   const nopeAction = () =>{
     console.log('activate nope')
@@ -182,189 +352,30 @@ export const useCardActions = ()=>{
       prev=>prev.filter(prev=>prev!==cardTypes.exploding.type)
     )
     if(!setActionPrompt) return 
-    setActionPrompt([
-        {
-          text:'choose a position to put the card back in. 0 is on top',
-          options:{
-            ['deck-placement']:(deck ?? []).map((_,index)=>({
-              value:index,
-              display:index
-            }))
-          },
-          submitCallBack:(formData:FormData)=>{
-            const deckPlacement = formData?.get('deck-placement')?.toString()
-            console.log('deck placement',deckPlacement, typeof deckPlacement)
-            if(!deckPlacement){
-              console.log('error: no deck placement found')
-              return
-            }
-            if(!deck){
-              console.log('error: deck not found')
-              return
-            }
-            const discardedExploding = discardPile?.find(card=>card.type===actionTypes.exploding)
-            if(!discardedExploding){
-              console.log('error: no exploding card found')
-              return
-            }
-            const newDeck = [...deck ?? []]
-            newDeck.splice(deck.length - parseInt(deckPlacement),0,discardedExploding)
-            socket?.emit('deck',newDeck)
-            socket?.emit('discard-pile',discardPile?.filter(c=>c.id!==discardedExploding.id) || [])
-            submitResponseEvent('',{},'',true)
-          }
-        },
-      ]
-    )
+    setActionPrompt(diffuseActionPrompts)
     setActionsComplete(prev=>prev+1)
     console.log('diffuse')
   }
 
   const favorAction = ()=>{
     if(!setActionPrompt) return
-    setActionPrompt([
-        {
-          text:'Choose a player to steal a card from',
-          options:{
-            username:[...players
-            ?.filter(p=>p.username!==currentPlayer?.username)
-            ?.map(p=>({
-              value:p.username,
-              display:p.username
-            }))??[]]
-          },
-          submitCallBack:(formData:FormData)=>{
-            const playerSelectedUsername = formData?.get('username')?.toString()
-            const customCardsOption = {
-              card:players?.find(p=>p.username===playerSelectedUsername)?.cards?.map(c=>({
-                value:c.type,
-                display:`${c.type} - ${c.id}`
-              })) ?? []
-            }
-            submitResponseEvent(playerSelectedUsername || '',customCardsOption)
-          }
-        },
-        {
-          text:'Choose a card to give away',
-          options:{},
-          submitCallBack:(formData:FormData)=>{
-            const cardType = formData.get('card')
-
-            const currentPlayerIndex = players?.findIndex(p=>p.username==currentPlayer?.username)
-            if(!currentPlayerIndex && currentPlayerIndex!==0){
-              console.error('current player index not found')
-              return
-            }
-
-            const newCard = players?.[currentPlayerIndex]
-              ?.cards
-              ?.find(c=>c.type===cardType)
-            
-            removeCardsFromHand(socket,[...(newCard?[newCard]:[])],currentPlayer?.username,players)
-            addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
-
-            submitResponseEvent('',{},'',true)
-          }
-        }
-      ]
-    )
+    setActionPrompt(favorActionPrompts)
   }
 
   const multiple2Action = ()=>{
     if(!setActionPrompt) return
-    setActionPrompt([
-        {
-          text:'Choose a player to steal a card from',
-          options:{
-            username:[...players
-            ?.filter(p=>p.username!==currentPlayer?.username)
-            ?.map(p=>({
-              value:p.username,
-              display:p.username
-            }))??[]]
-          },
-          submitCallBack:(formData:FormData)=>{
-            const playerSelectedUsername = formData?.get('username')?.toString()
-            const selectedPlayerIndex = players?.findIndex(p=>p.username==currentPlayer?.username)
-            if(!selectedPlayerIndex && selectedPlayerIndex!==0){
-              console.error('current player index not found')
-              return
-            }
-
-            const cardsShuffled = shuffleArray(players?.[selectedPlayerIndex].cards ?? [])
-            const newCard = cardsShuffled[0]
-            
-            removeCardsFromHand(socket,[...(newCard?[newCard]:[])],playerSelectedUsername,players)
-            addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
-            
-            submitResponseEvent('',{},'',true)
-          }
-        },
-      ]
-    )
+    setActionPrompt(multiple2ActionPrompts)
   }
 
   const multiple3Action = ()=>{
     if(!setActionPrompt) return
-    setActionPrompt([
-        {
-          text:'Choose a player to steal from and a card type',
-          options:{
-            username:[...players
-            ?.filter(p=>p.username!==currentPlayer?.username)
-            ?.map(p=>({
-              value:p.username,
-              display:p.username
-            }))??[]],
-            card:Object.values(cardTypes).map(card=>({
-              value:card.type,
-              display:card.type
-            }))
-          },
-          submitCallBack:(formData:FormData)=>{
-            const playerSelectedUsername = formData?.get('username')?.toString()
-            const cardTypeSelected = formData?.get('card')?.toString()
-            
-            const newCard = players?.find(p=>p.username === playerSelectedUsername)
-              ?.cards?.find(card=>card.type===cardTypeSelected)
-            
-            if(!newCard){
-              submitResponseEvent(turnPlayer.username,{})
-              return
-            }
-
-            removeCardsFromHand(socket,[...(newCard?[newCard]:[])],playerSelectedUsername,players)
-            addCardsToHand(socket,[...(newCard?[newCard]:[])],turnPlayer?.username,players)
-            
-            submitResponseEvent('',{},'',true)
-          }
-        },
-        {
-          text:'Card is Not Found',
-          options:{},
-          submitCallBack:()=>{
-            submitResponseEvent('',{},'',true)
-          }
-        }
-      ]
-    )
+    setActionPrompt(multiple3ActionPrompts)
   }
 
   const seeTheFutureAction = ()=>{
     console.log('shuffle action')
     if(!setActionPrompt) return 
-    setActionPrompt([
-        {
-          text:`${deck?.slice(deck.length-3).map(
-            c=>`${c.type} - ${c.id}`
-          ).join()}`,
-          options:{},
-          submitCallBack:()=>{
-            submitResponseEvent('',{},'',true)
-          }
-        },
-      ]
-    )
+    setActionPrompt(seeTheFutureActionPrompts)
   }
 
   const attackAction = ()=>{
@@ -399,7 +410,12 @@ export const useCardActions = ()=>{
   }
 
   const skip = ()=>{
-
+    console.log('skip')
+    if(attackTurns){
+      if(setAttackTurns)setAttackTurns(prev=>prev-1)
+      return
+    }
+    if(setTurnCount)(setTurnCount(prev=>prev+1))
   }
 
   type ActionImpl =  {
@@ -415,8 +431,16 @@ export const useCardActions = ()=>{
     [actionTypes.multiple3]:multiple3Action,
     [actionTypes.nope]:nopeAction,
     [actionTypes.seeTheFuture]:seeTheFutureAction,
-    [actionTypes.shuffle]:()=>shuffleAction,
-    [actionTypes.skip]:()=>null,
+    [actionTypes.shuffle]:shuffleAction,
+    [actionTypes.skip]:skip,
+  }
+
+  const actionPromptsData = {
+    [actionTypes.diffuse]:diffuseActionPrompts,
+    [actionTypes.multiple2]:multiple2ActionPrompts,
+    [actionTypes.multiple3]:multiple3ActionPrompts,
+    [actionTypes.favor]:favorActionPrompts,
+    [actionTypes.seeTheFuture]:seeTheFutureActionPrompts
   }
 
 
@@ -424,5 +448,6 @@ export const useCardActions = ()=>{
     actions,
     actionsComplete,
     setActionsComplete,
+    actionPromptsData
   }
 }

--- a/exploding-kittens-frontend/src/lib/helpers.ts
+++ b/exploding-kittens-frontend/src/lib/helpers.ts
@@ -48,3 +48,7 @@ export const addCardsToHand = (
 
   socket.emit('all-players',playersCopy)
 }
+
+export const getNonLostPlayers = (players:Player[])=>(
+  players.filter(p=>!p.lose)
+)

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -265,11 +265,11 @@ export const useInitGame = () => {
   }
 
   const createDeck=()=>{
-      const randomizedDeck = [
+      const randomizedDeck = shuffleArray([
         ...initialDeck,
         ...explodingKittenCards.slice(0,(players?.length ?? 1)-1),
         ...diffuseCards
-      ].sort(() => Math.random() - 0.5)
+      ])
       socket?.emit('deck',[...randomizedDeck,{
         ...explodingKittenCards[0],
         id:1000

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -309,7 +309,12 @@ export const useTurns = ({initListeners}:UseTurnsProps={initListeners:false})=>{
   const {currentPlayer,players: allPlayers} = usePlayerContext() ||{}
   const {deck} = useGameStateContext() || {}
   const players = getNonLostPlayers(allPlayers ?? [])
-  const gameOver = players.length===1 && deck?.length
+  
+  //will be false if no winner
+  const winner: Player | boolean = players.length>1
+    && !!deck?.length
+    && players.filter(player=>!player.lose).length===1 
+    && (players?.find(player=>!player.lose) ?? false)
 
   const {attemptActivate,currentActions} = useActivateResponseHandlers()
   const {drawCard} = useGameActions()
@@ -358,6 +363,6 @@ export const useTurns = ({initListeners}:UseTurnsProps={initListeners:false})=>{
     endTurn,
     isTurnEnd,
     turnPlayer,
-    gameOver
+    winner
   }
 }

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -26,6 +26,7 @@ declare global{
     cards: Card[]
   }
   type ActionPromptData = {
+    showToUser?:string
     text?:string
     options:{
       [key:string]:{value:string | number,display:string | number}[]
@@ -50,9 +51,7 @@ declare global{
     ['turn-count']: (arg:number) => void
     ['discard-pile']: (arg:Card[]) => void
     ['next-action-response']: (arg:{
-      showToUser:string
-      customOptions?:ActionPromptData["options"]
-      customText?:string
+      formObject:{[key:string]:any}
       complete:boolean
     }) => void
   }
@@ -73,9 +72,7 @@ declare global{
     ['turn-count']: (arg:number) => void
     ['discard-pile']: (arg:Card[]) => void
     ['next-action-response']: (arg:{
-      showToUser:string
-      customOptions?:ActionPromptData["options"]
-      customText?:string
+      formObject:{[key:string]:any}
       complete:boolean
     }) => void
   }

--- a/exploding-kittens-frontend/src/types/global.d.ts
+++ b/exploding-kittens-frontend/src/types/global.d.ts
@@ -28,7 +28,7 @@ declare global{
   type ActionPromptData = {
     text?:string
     options:{
-      [key:string]:{value:string,display:string}[]
+      [key:string]:{value:string | number,display:string | number}[]
     }
     submitCallBack: Function
   }


### PR DESCRIPTION
# Description
1. Added implementation for the remaining actions:

- Exploding
- Diffuse(added functionality at add back exploding card in any order)
- Skip
- Shuffle

2. Refactored `ActionPrompt` in gameState so each prompt is a callbacks and takes in formData of previous response submission. That way we can remove the `customOption`, `customText`, and `showToUser` socket data. Also updated submitResponseEvent to now longer require those params and to take in an object so positional args don't need to be used.
```

//previous

    setActionPrompt([
        {
          text:'Choose a player to steal a card from',
          options:{
            username:[...players
            ?.filter(p=>p.username!==currentPlayer?.username)
            ?.map(p=>({
              value:p.username,
              display:p.username
            }))??[]]
          },
          submitCallBack:(formData:FormData)=>{
            const playerSelectedUsername = formData?.get('username')?.toString()

           // options that are derived from last response like cards of a selected player need to be set this way before
            const customCardsOption = {
              card:players?.find(p=>p.username===playerSelectedUsername)?.cards?.map(c=>({
                value:c.type,
                display:`${c.type} - ${c.id}`
              })) ?? []
            }

            submitResponseEvent(playerSelectedUsername || '',customCardsOption)
          }
        },
        {
          text:'Choose a card to give away',
          options:{},
          ...
      ]


//new action prompts
[
    ()=>({
      showToUser:turnPlayer.username,
      text:'Choose a player to steal a card from',
      ...
      submitCallBack:(formData:FormData)=>{
        submitResponseEvent({formData})
      }
    }),
    (previousAnswerObject?:{[key:string]: any})=>({
    // showToUser can be directly set here since we now have access to previousAnswerObject
      showToUser:previousAnswerObject?.username,
      text:'Choose a card to give away',
     //options that used last answer can be set the same way now
      options:{
        card:players?.find(p=>p.username===previousAnswerObject?.username)?.cards?.map(c=>({
          value:c.type,
          display:`${c.type} - ${c.id}`
        })) ?? []
      },
      submitCallBack:(formData:FormData)=>{
...      }
    })

//ActionPrompt.tsx component

//to access prompt data the component now using a calls the step in the state with args of previousData set from last response socket event.
  const [previousSubmitData,setPreviousSubmitData] = useState<{[key:string]:any}>({})

  const currentActionPrompt = actionPrompt?.[responseCount]?.(previousSubmitData)


  useEffect(()=>{
    if(!socket) return
    socket?.on('next-action-response',(data)=>{
      if(data.formObject)setPreviousSubmitData(data.formObject)
    ....
    })
  },[socket])
```

3. Added action Prompts for each action in a separate variable and exported them, thinking this will be easier for pausing game functionality later.