### PR TITLE
frontend auth helper

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -36,7 +36,7 @@ const refresh = async (req, res) => {
   console.log('succesful refresh')
   console.log('access token:', req.cookies['accessToken'])
   console.log('refresh token:', req.cookies['refreshToken'])
-  return res.send({ refreshSuccess: true })
+  return res.send(req.user)
 }
 
 export default {

--- a/backend/helpers/index.js
+++ b/backend/helpers/index.js
@@ -68,6 +68,7 @@ export const authenticate = (req, res, next) => {
       return next()
     }
     console.log('success, valid access token')
+    req.user = accessResult.data
     next()
   } catch (e) {
     return console.error(e)

--- a/exploding-kittens-frontend/src/lib/helpers.ts
+++ b/exploding-kittens-frontend/src/lib/helpers.ts
@@ -52,3 +52,18 @@ export const addCardsToHand = (
 export const getNonLostPlayers = (players:Player[])=>(
   players.filter(p=>!p.lose)
 )
+
+export const authenticate = async () => {
+  return await fetch('http://localhost:3000/auth/refresh', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include'
+  })
+  .then(res => res.json())
+  .then((user: User) => {
+    console.log('user:', user)
+    return user
+  })
+}


### PR DESCRIPTION
Added an `authenticate` function to frontend for checking/refreshing credentials. Upon success, it returns a User object that can be used to update `currentPlayer` in `playerContext`

There may be a better way to do this, but while I was navigating around the site , I noticed that player context was disappearing upon refreshes or if using the url to navigate. These might not be a common case, but now we can run `authenticate()` in the front end if no player context exists where we would it expect it to. An api call will be made to the backend `/refresh` route and check tokens etc.