### PR TITLE
Auth on the front and back

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -34,9 +34,16 @@ const login = async (req, res) => {
 
 const refresh = async (req, res) => {
   console.log('succesful refresh')
-  console.log('access token:', req.cookies['accessToken'])
-  console.log('refresh token:', req.cookies['refreshToken'])
-  return res.send(req.user)
+  console.log('access token:', req.accessToken)
+  console.log('refresh token:', req.refreshToken)
+  console.log('user: ', req.user)
+  const existingUser = await User.findOne({username: req.user.username})
+  const { username, rooms, wins, id, _id } = existingUser
+  return res
+    .cookie('accessToken', req.accessToken, { httpOnly: true })
+    .cookie('refreshToken', req.refreshToken, { httpOnly: true })
+    .json({username, rooms, wins, id, _id})
+    .status(200)
 }
 
 export default {

--- a/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/OtherPlayers.tsx
@@ -1,12 +1,13 @@
 import { usePlayerContext } from "@/context/players";
 
 const OtherPlayers = ()=>{
-  const {players} = usePlayerContext() || {}
-
+  const {players, currentPlayer} = usePlayerContext() || {}
   return(
     <div>
       Other Players
-      {players?.map(player=>(
+      {players
+        ?.filter((player: Player) => player.username !== currentPlayer?.username)
+        .map(player=>(
         <div className="border border-black" key={player.username}>
           <div className="flex items-center">
           {player.username}:&nbsp;

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -55,8 +55,8 @@ const Room = ({params}:RoomParams)=>{
   return (
     <div className="w-full">
       {winner && <div>Game Over! winner is: {winner.username}</div>}
-      Room Number: {params.roomNumber}
-      {JSON.stringify(players)}
+      Room Number: {params.roomNumber} <br/>
+      {JSON.stringify(players)} <br/>
       {JSON.stringify(users)}
       <div className="border border-black">
         <h1>join room</h1>
@@ -93,8 +93,12 @@ const Room = ({params}:RoomParams)=>{
           Discard:
           {JSON.stringify(discardPile)}
         </div>
-        <button onClick={createGameAssets} className="btn btn-blue">
-            create game assets(need at least one joined user for this to work)
+        <button 
+          onClick={createGameAssets} 
+          className="btn btn-blue" 
+          disabled={players && players.length < 3}
+        >
+          create game assets(need at least one joined user for this to work)
         </button>
       </div>
     </div>

--- a/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
+++ b/exploding-kittens-frontend/src/app/[roomNumber]/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import {useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
 import { usePlayerContext } from "@/context/players"
 import { useGameStateContext } from "@/context/gameState"
 import {
@@ -7,6 +8,7 @@ import {
   usePlayerSocket ,
   useTurns
 } from "@/lib/hooks"
+import { authenticate } from "@/lib/helpers"
 import Hand from "@/app/[roomNumber]/hand"
 import OtherPlayers from "@/app/[roomNumber]/OtherPlayers"
 
@@ -18,7 +20,8 @@ type RoomParams = {
 }
 
 const Room = ({params}:RoomParams)=>{
-  const playerContext = usePlayerContext() || {}
+  const router = useRouter()
+  const {players,currentPlayer,setCurrentPlayer} = usePlayerContext() || {}
   const {deck,discardPile} = useGameStateContext() || {}
   const {winner} = useTurns() || {}
 
@@ -38,11 +41,22 @@ const Room = ({params}:RoomParams)=>{
       })
   },[])
 
+  useEffect(() => {
+    const setData = async () => {
+      const playerData = await authenticate()
+      if (playerData && setCurrentPlayer) setCurrentPlayer(playerData)
+      else router.push('/auth/login')
+    }
+    if (!currentPlayer) {
+      setData()
+    }
+  }, [])
+
   return (
     <div className="w-full">
       {winner && <div>Game Over! winner is: {winner.username}</div>}
       Room Number: {params.roomNumber}
-      {JSON.stringify(playerContext)}
+      {JSON.stringify(players)}
       {JSON.stringify(users)}
       <div className="border border-black">
         <h1>join room</h1>

--- a/exploding-kittens-frontend/src/lib/hooks.tsx
+++ b/exploding-kittens-frontend/src/lib/hooks.tsx
@@ -44,7 +44,7 @@ export const usePlayerSocket=()=>{
         username,
         ...(room?{room}:{})
       })
-      if(setCurrentPlayer) setCurrentPlayer({...currentPlayer,username})
+      // if(setCurrentPlayer) setCurrentPlayer({...currentPlayer,username})
     }else{
       console.error('socket not initialized yet')
     }


### PR DESCRIPTION
### Backend
- JWT flow was not operating correctly. Cookies were being set incorrectly when the `accessToken` was invalid but the `refreshToken` was still good. Adjusted the logic so that the tokens are set and sent (correctly) in the `/refresh` route 
- Sending `false` back if neither token is valid so that frontend can redirect to the login page

### Frontend
- Added an `authenticate()` check to `/[roomNumber]` route that redirects to the login page if both tokens are invalid
- Commented out a part of `joinRoom` helper that was setting `currentPlayer` each time a player is added